### PR TITLE
Proposal to support passing target version when cross compiling

### DIFF
--- a/src/Veldrid.SPIRV/CrossCompileInfo.cs
+++ b/src/Veldrid.SPIRV/CrossCompileInfo.cs
@@ -6,6 +6,7 @@ namespace Veldrid.SPIRV
     internal struct CrossCompileInfo
     {
         public CrossCompileTarget Target;
+        public uint TargetVersion;
         public Bool32 FixClipSpaceZ;
         public Bool32 InvertY;
         public Bool32 NormalizeResourceNames;

--- a/src/libveldrid-spirv/InteropStructs.hpp
+++ b/src/libveldrid-spirv/InteropStructs.hpp
@@ -122,6 +122,7 @@ enum CrossCompileTarget : uint32_t
 struct CrossCompileInfo
 {
     CrossCompileTarget Target;
+    uint32_t TargetVersion;
     Bool32 FixClipSpaceZ;
     Bool32 InvertY;
     Bool32 NormalizeResourceNames;

--- a/src/libveldrid-spirv/libveldrid-spirv.cpp
+++ b/src/libveldrid-spirv/libveldrid-spirv.cpp
@@ -190,7 +190,14 @@ Compiler *GetCompiler(std::vector<uint32_t> spirvBytes, const CrossCompileInfo &
     {
         auto ret = new CompilerHLSL(spirvBytes);
         CompilerHLSL::Options opts = {};
-        opts.shader_model = 50;
+        if(info.TargetVersion != 0)
+        {
+            opts.shader_model = info.TargetVersion;
+        }
+        else
+        {
+            opts.shader_model = 50;
+        }
         opts.point_size_compat = true;
         ret->set_hlsl_options(opts);
         CompilerGLSL::Options commonOpts;
@@ -206,13 +213,20 @@ Compiler *GetCompiler(std::vector<uint32_t> spirvBytes, const CrossCompileInfo &
         CompilerGLSL::Options opts = {};
         opts.es = info.Target == ESSL;
         opts.enable_420pack_extension = false;
-        if (info.ComputeShader.Count > 0)
+        if(info.TargetVersion != 0)
         {
-            opts.version = info.Target == GLSL ? 430 : 310;
+            opts.version = info.TargetVersion;
         }
         else
         {
-            opts.version = info.Target == GLSL ? 330 : 300;
+            if (info.ComputeShader.Count > 0)
+            {
+                opts.version = info.Target == GLSL ? 430 : 310;
+            }
+            else
+            {
+                opts.version = info.Target == GLSL ? 330 : 300;
+            }
         }
         opts.vertex.fixup_clipspace = info.FixClipSpaceZ;
         opts.vertex.flip_vert_y = info.InvertY;
@@ -223,6 +237,10 @@ Compiler *GetCompiler(std::vector<uint32_t> spirvBytes, const CrossCompileInfo &
     {
         auto ret = new CompilerMSL(spirvBytes);
         CompilerMSL::Options opts = {};
+        if(info.TargetVersion != 0)
+        {
+            opts.msl_version = info.TargetVersion;
+        }
         ret->set_msl_options(opts);
         CompilerGLSL::Options commonOpts;
         commonOpts.vertex.flip_vert_y = info.InvertY;


### PR DESCRIPTION
* adds TargetVersion to CrossCompileInfo so that the caller can control
  the target compilation version (if 0 is passed, the behavior is as
  before)
* adds targetVersion param to SpirvCompilation.CompileCompute/CompileVertexFragment
* adds
  SpirvCompilation.SetDefaultTargetVersionForCrossCompileTarget(CrossCompileTarget,
  uint version) to allow caller to set global default to avoid having to
  pass versions into every Compile call

While working on the [PBR sample](https://github.com/mellinoe/veldrid-samples/pull/40), I found that I ran into compilation errors due to the default MSL version being too low.  This change allows me to set the MSL version as seen [here](https://github.com/mellinoe/veldrid-samples/blob/55f99ea2e00e1b3c8680aa8ca829d0b8b007a2d4/src/PBR/Application/PBR/PBRApplication.cs#L60).