### PR TITLE
Add the ability to transpile SPIRV geometry shaders

### DIFF
--- a/src/Veldrid.SPIRV/CrossCompileInfo.cs
+++ b/src/Veldrid.SPIRV/CrossCompileInfo.cs
@@ -13,5 +13,6 @@ namespace Veldrid.SPIRV
         public InteropArray VertexShader;
         public InteropArray FragmentShader;
         public InteropArray ComputeShader;
+        public InteropArray GeometryShader;
     }
 }

--- a/src/Veldrid.SPIRV/GeometryCompilationResult.cs
+++ b/src/Veldrid.SPIRV/GeometryCompilationResult.cs
@@ -1,0 +1,24 @@
+﻿namespace Veldrid.SPIRV
+{
+    /// <summary>
+    /// The output of a cross-compile operation of a compute shader from SPIR-V to some target language.
+    /// </summary>
+    public class GeometryCompilationResult
+    {
+        /// <summary>
+        /// The translated shader source code.
+        /// </summary>
+        public string GeometryShader { get; }
+        /// <summary>
+        /// Information about the resources used in the compiled shader.
+        /// </summary>
+        public SpirvReflection Reflection { get; }
+
+        internal GeometryCompilationResult(string geometryCode, SpirvReflection reflection)
+        {
+            this.GeometryShader = geometryCode;
+            Reflection = reflection;
+        }
+    }
+
+}

--- a/src/libveldrid-spirv/InteropStructs.hpp
+++ b/src/libveldrid-spirv/InteropStructs.hpp
@@ -129,6 +129,7 @@ struct CrossCompileInfo
     InteropArray<uint32_t> VertexShader;
     InteropArray<uint32_t> FragmentShader;
     InteropArray<uint32_t> ComputeShader;
+    InteropArray<uint32_t> GeometryShader;
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
This does not support transpiling to HLSL, but it works for all other transpilation targets