### PR TITLE
Use valid `osx` runtime identifier instead of `osx-universal`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             artifact_name: build/Release/libveldrid-spirv.so
           - os: macos-latest
             build_args: release -osx-architectures 'arm64;x86_64'
-            build_target: osx-universal
+            build_target: osx
             artifact_name: build/Release/libveldrid-spirv.dylib
           - os: macos-latest
             build_args: release ios
@@ -121,10 +121,10 @@ jobs:
           name: linux-x64
           path: build/Release
 
-      - name: Download osx-universal
+      - name: Download osx
         uses: actions/download-artifact@v2
         with:
-          name: osx-universal
+          name: osx
           path: build/Release
 
       - name: Download ios

--- a/build-full-package.ps1
+++ b/build-full-package.ps1
@@ -21,7 +21,7 @@ New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration 
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\win-x86 | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\win-x64 | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\linux-x64 | Out-Null
-New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\osx-universal | Out-Null
+New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\osx | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\ios | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\android-arm64-v8a | Out-Null
 New-Item -ItemType Directory -Force -Path $PSScriptRoot\download\$configuration\android-x86_64 | Out-Null
@@ -68,14 +68,14 @@ Write-Host "- libveldrid-spirv.so (64-bit Linux)"
 
 $client.DownloadFile(
     "https://github.com/mellinoe/veldrid-spirv/releases/download/$tag/libveldrid-spirv.dylib",
-    "$PSScriptRoot/download/$configuration/osx-universal/libveldrid-spirv.dylib")
+    "$PSScriptRoot/download/$configuration/osx/libveldrid-spirv.dylib")
 if( -not $? )
 {
     $msg = $Error[0].Exception.Message
     Write-Error "Couldn't download libveldrid-spirv.dylib. This most likely indicates the macOS native build failed."
     exit
 }
-Write-Host "- libveldrid-spirv.dylib (64-bit macOS)"
+Write-Host "- libveldrid-spirv.dylib (macOS universal)"
 
 $client.DownloadFile(
     "https://github.com/mellinoe/veldrid-spirv/releases/download/$tag/libveldrid-spirv-combined.a",

--- a/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj
+++ b/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj
@@ -40,7 +40,7 @@
       <_NativeAssetName Include="$(Configuration)/win-x86/libveldrid-spirv.dll" PackagePath="runtimes/win-x86/native" />
       <_NativeAssetName Include="$(Configuration)/win-x64/libveldrid-spirv.dll" PackagePath="runtimes/win-x64/native" />
       <_NativeAssetName Include="$(Configuration)/linux-x64/libveldrid-spirv.so" PackagePath="runtimes/linux-x64/native" />
-      <_NativeAssetName Include="$(Configuration)/osx-universal/libveldrid-spirv.dylib" PackagePath="runtimes/osx-universal/native" />
+      <_NativeAssetName Include="$(Configuration)/osx/libveldrid-spirv.dylib" PackagePath="runtimes/osx/native" />
       <_NativeAssetName Include="$(Configuration)/ios/libveldrid-spirv-combined.a" PackagePath="build/Xamarin.iOS10/native" />
       <_NativeAssetName Include="$(Configuration)/android-arm64-v8a/libveldrid-spirv.so" PackagePath="build/MonoAndroid10/native/arm64-v8a" />
       <_NativeAssetName Include="$(Configuration)/android-armeabi-v7a/libveldrid-spirv.so" PackagePath="build/MonoAndroid10/native/armeabi-v7a" />


### PR DESCRIPTION
The identifier `osx` is a valid RID for storing fat libraries which work across both Intel and Apple Silicon platforms, and matches the [specification documented in .NET](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog):
```
    win7-x64    win7-x86
       |   \   /    |
       |   win7     |
       |     |      |
    win-x64  |  win-x86
          \  |  /
            win
             |
            any
```

For testing convenience, I've published a [nuget package](https://www.nuget.org/packages/frenzi.Veldrid.SPIRV) with these changes included, using the `build-full-package.ps1` script directed at a [fork repo release](https://github.com/frenzibyte/veldrid-spirv/releases/tag/2022.421.0).

@mellinoe would appreciate if you can look into this and publish a new release, as it's a blocker for me on macOS M1.

---

As a sanity check, using this test code I wrote on a fresh .NET 6 project:
```csharp
// See https://aka.ms/new-console-template for more information

using Veldrid.SPIRV;

Veldrid.SPIRV.SpirvCompilation.CompileVertexFragment(Array.Empty<byte>(), Array.Empty<byte>(), CrossCompileTarget.MSL, new CrossCompileOptions());
```

Running this using a package that has the fat libraries in `osx-universal` will result in `DllNotFoundException`:
```
/Users/salman/RiderProjects/ConsoleApp1/NETSandbox/bin/Debug/net6.0/NETSandbox
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'libveldrid-spirv' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(liblibveldrid-spirv, 0x0001): tried: 'liblibveldrid-spirv' (no such file), '/usr/local/lib/liblibveldrid-spirv' (no such file), '/usr/lib/liblibveldrid-spirv' (no such file), '/Users/salman/RiderProjects/ConsoleApp1/NETSandbox/bin/Debug/net6.0/liblibveldrid-spirv' (no such file)
   at Veldrid.SPIRV.VeldridSpirvNative.CompileGlslToSpirv(GlslCompileInfo* info)
   at Veldrid.SPIRV.SpirvCompilation.CompileGlslToSpirv(UInt32 sourceLength, Byte* sourceTextPtr, String fileName, ShaderStages stage, Boolean debug, UInt32 macroCount, NativeMacroDefinition* macros)
   at Veldrid.SPIRV.SpirvCompilation.CompileVertexFragment(Byte[] vsBytes, Byte[] fsBytes, CrossCompileTarget target, CrossCompileOptions options)
   at Program.<Main>$(String[] args) in /Users/salman/RiderProjects/ConsoleApp1/NETSandbox/Program.cs:line 5
```

While running this package on `osx` instead shows that the library has been found:
```
/Users/salman/RiderProjects/ConsoleApp1/NETSandbox/bin/Debug/net6.0/NETSandbox
Unhandled exception. Veldrid.SPIRV.SpirvCompilationException: Compilation failed: <veldrid-spirv-input>: error: #version: Desktop shaders for Vulkan SPIR-V require version 140 or higher

   at Veldrid.SPIRV.SpirvCompilation.CompileGlslToSpirv(UInt32 sourceLength, Byte* sourceTextPtr, String fileName, ShaderStages stage, Boolean debug, UInt32 macroCount, NativeMacroDefinition* macros)
   at Veldrid.SPIRV.SpirvCompilation.CompileVertexFragment(Byte[] vsBytes, Byte[] fsBytes, CrossCompileTarget target, CrossCompileOptions options)
   at Program.<Main>$(String[] args) in /Users/salman/RiderProjects/ConsoleApp1/NETSandbox/Program.cs:line 5
```