### PR TITLE
Standardise native build output directory and improve CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,13 +152,10 @@ jobs:
       - name: Restore Dependencies
         run: dotnet restore src
 
-      - name: Build Project
-        run: dotnet build -c Release --no-restore src
+      - name: Build NuGet Package
+        run: dotnet pack src/Veldrid.SPIRV -c Release --no-restore
 
-      - name: Build Packages
-        run: dotnet pack src/Veldrid.SPIRV -c Release --no-restore --no-build
-
-      - name: Upload NuGet package
+      - name: Upload NuGet Package
         uses: actions/upload-artifact@v2
         with:
           name: nuget_package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Get Submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ jobs:
             build_target: win-x86
             artifact_name: build\Release\win-x86\libveldrid-spirv.dll
           - os: windows-latest
-            build_args: release --android-ndk '%ANDROID_NDK_HOME%' --android-abi arm64-v8a
+            build_args: release android arm64-v8a --android-ndk '%ANDROID_NDK_HOME%'
             build_target: android-arm64-v8a
             artifact_name: build\Release\android-arm64-v8a\libveldrid-spirv.so
           - os: windows-latest
-            build_args: release --android-ndk '%ANDROID_NDK_HOME%' --android-abi x86_64
+            build_args: release android x86_64 --android-ndk '%ANDROID_NDK_HOME%'
             build_target: android-x86_64
             artifact_name: build\Release\android-x86_64\libveldrid-spirv.so
           - os: windows-latest
-            build_args: release --android-ndk '%ANDROID_NDK_HOME%' --android-abi armeabi-v7a
+            build_args: release android armeabi-v7a --android-ndk '%ANDROID_NDK_HOME%'
             build_target: android-armeabi-v7a
             artifact_name: build\Release\android-armeabi-v7a\libveldrid-spirv.so
           - os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,20 @@ jobs:
               fi
         shell: bash
 
+      # We can only run per-platform tests on 64-bit architectures
+      # https://github.com/actions/setup-dotnet/issues/72
       - name: Install .NET
+        if: ${{ matrix.build_target == 'win-x64' || matrix.build_target == 'osx' || matrix.build_target == 'linux-x64' }}
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
 
       - name: Restore Dependencies
+        if: ${{ matrix.build_target == 'win-x64' || matrix.build_target == 'osx' || matrix.build_target == 'linux-x64' }}
         run: dotnet restore src
 
       - name: Run Tests
+        if: ${{ matrix.build_target == 'win-x64' || matrix.build_target == 'osx' || matrix.build_target == 'linux-x64' }}
         run: dotnet run -p src/Veldrid.SPIRV.Tests/Veldrid.SPIRV.Tests.csproj -c Release --no-restore
 
       - name: Upload ${{ matrix.build_target }} Native Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,17 @@ jobs:
               fi
         shell: bash
 
+      - name: Install .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Restore Dependencies
+        run: dotnet restore src
+
+      - name: Run Tests
+        run: dotnet run -p src/Veldrid.SPIRV.Tests/Veldrid.SPIRV.Tests.csproj -c Release --no-restore
+
       - name: Upload ${{ matrix.build_target }} Native Library
         uses: actions/upload-artifact@v2
         with:
@@ -138,14 +149,11 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: Restore dependencies
+      - name: Restore Dependencies
         run: dotnet restore src
 
       - name: Build Project
         run: dotnet build -c Release --no-restore src
-
-      - name: Run Tests
-        run: dotnet run -p src/Veldrid.SPIRV.Tests/Veldrid.SPIRV.Tests.csproj -c Release
 
       - name: Build Packages
         run: dotnet pack src/Veldrid.SPIRV -c Release --no-restore --no-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,17 +32,17 @@ jobs:
             build_target: android-armeabi-v7a
             artifact_name: build\android-armeabi-v7a\libveldrid-spirv.so
           - os: ubuntu-latest
-            build_args: release
+            build_args: release linux-x64
             build_target: linux-x64
-            artifact_name: build/Release/libveldrid-spirv.so
+            artifact_name: build/Release/linux-x64/libveldrid-spirv.so
           - os: macos-latest
-            build_args: release -osx-architectures 'arm64;x86_64'
+            build_args: release osx 'arm64;x86_64'
             build_target: osx
-            artifact_name: build/Release/libveldrid-spirv.dylib
+            artifact_name: build/Release/osx/libveldrid-spirv.dylib
           - os: macos-latest
             build_args: release ios
             build_target: ios
-            artifact_name: build/ios-Release/Release-iphoneos/libveldrid-spirv-combined.a
+            artifact_name: build/Release/ios/libveldrid-spirv-combined.a
     name: ${{ matrix.build_target }} Native Build
 
     steps:
@@ -119,19 +119,19 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: linux-x64
-          path: build/Release
+          path: build/Release/linux-x64
 
       - name: Download osx
         uses: actions/download-artifact@v2
         with:
           name: osx
-          path: build/Release
+          path: build/Release/osx
 
       - name: Download ios
         uses: actions/download-artifact@v2
         with:
           name: ios
-          path: build/Release
+          path: build/Release/ios
 
       - name: Install .NET
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,25 +12,25 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            build_args: Release win-x64 --artifact-name build\\win-x64\\libveldrid-spirv.dll
+            build_args: release win-x64
             build_target: win-x64
-            artifact_name: build\win-x64\libveldrid-spirv.dll
+            artifact_name: build\Release\win-x64\libveldrid-spirv.dll
           - os: windows-latest
-            build_args: Release win-x86 --artifact-name build\\win-x86\\libveldrid-spirv.dll
+            build_args: Release win-x86
             build_target: win-x86
-            artifact_name: build\win-x86\libveldrid-spirv.dll
+            artifact_name: build\Release\win-x86\libveldrid-spirv.dll
           - os: windows-latest
-            build_args: Release --android-ndk '%ANDROID_NDK_HOME%' --android-abi arm64-v8a --artifact-name build\\android-arm64-v8a\\libveldrid-spirv.so
+            build_args: release --android-ndk '%ANDROID_NDK_HOME%' --android-abi arm64-v8a
             build_target: android-arm64-v8a
-            artifact_name: build\android-arm64-v8a\libveldrid-spirv.so
+            artifact_name: build\Release\android-arm64-v8a\libveldrid-spirv.so
           - os: windows-latest
-            build_args: Release --android-ndk '%ANDROID_NDK_HOME%' --android-abi x86_64 --artifact-name build\\android-x86_64\\libveldrid-spirv.so
+            build_args: release --android-ndk '%ANDROID_NDK_HOME%' --android-abi x86_64
             build_target: android-x86_64
-            artifact_name: build\android-x86_64\libveldrid-spirv.so
+            artifact_name: build\Release\android-x86_64\libveldrid-spirv.so
           - os: windows-latest
-            build_args: Release --android-ndk '%ANDROID_NDK_HOME%' --android-abi armeabi-v7a --artifact-name build\\android-armeabi-v7a\\libveldrid-spirv.so
+            build_args: release --android-ndk '%ANDROID_NDK_HOME%' --android-abi armeabi-v7a
             build_target: android-armeabi-v7a
-            artifact_name: build\android-armeabi-v7a\libveldrid-spirv.so
+            artifact_name: build\Release\android-armeabi-v7a\libveldrid-spirv.so
           - os: ubuntu-latest
             build_args: release linux-x64
             build_target: linux-x64
@@ -89,31 +89,31 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: win-x64
-          path: build/Release
+          path: build/Release/win-x64
 
       - name: Download win-x86
         uses: actions/download-artifact@v2
         with:
           name: win-x86
-          path: build/Release
+          path: build/Release/win-x86
 
       - name: Download android-arm64-v8a
         uses: actions/download-artifact@v2
         with:
           name: android-arm64-v8a
-          path: build/Release
+          path: build/Release/android-arm64-v8a
 
       - name: Download android-x86_64
         uses: actions/download-artifact@v2
         with:
           name: android-x86_64
-          path: build/Release
+          path: build/Release/android-x86_64
 
       - name: Download android-armeabi-v7a
         uses: actions/download-artifact@v2
         with:
           name: android-armeabi-v7a
-          path: build/Release
+          path: build/Release/android-armeabi-v7a
 
       - name: Download linux-x64
         uses: actions/download-artifact@v2

--- a/build-local-package.cmd
+++ b/build-local-package.cmd
@@ -1,6 +1,6 @@
 @setlocal
 @echo off
 
-call .\build-native.cmd Release x86
-call .\build-native.cmd Release x64
+call .\build-native.cmd release win-x86
+call .\build-native.cmd release win-x64
 call dotnet pack -c Release src\Veldrid.SPIRV\Veldrid.SPIRV.csproj

--- a/build-local-package.sh
+++ b/build-local-package.sh
@@ -3,6 +3,8 @@
 scriptPath="`dirname \"$0\"`"
 
 _BuildConfig=Debug
+_Platform=
+_Arguments=
 
 while :; do
     if [ $# -le 0 ]; then
@@ -17,6 +19,14 @@ while :; do
         release|-release)
             _BuildConfig=Release
             ;;
+        osx)
+            _Platform=osx
+            _Arguments=$2
+            shift
+            ;;
+        linux-x64)
+            _Platform=linux-x64
+            ;;
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
     esac
@@ -24,5 +34,5 @@ while :; do
     shift
 done
 
-$scriptPath/build-native.sh $_BuildConfig
+$scriptPath/build-native.sh $_BuildConfig $_Platform $_Arguments
 dotnet pack -c $_BuildConfig $scriptPath/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj

--- a/build-native.cmd
+++ b/build-native.cmd
@@ -15,9 +15,8 @@ if /i [%1] == [release] (set _CMAKE_BUILD_TYPE=Release&& shift & goto ArgLoop)
 if /i [%1] == [debug] (set _CMAKE_BUILD_TYPE=Debug&& shift & goto ArgLoop)
 if /i [%1] == [win-x64] (set _BUILD_ARCH=x64&& set _CMAKE_GENERATOR_PLATFORM=x64&& shift & goto ArgLoop)
 if /i [%1] == [win-x86] (set _BUILD_ARCH=x86&& set _CMAKE_GENERATOR_PLATFORM=Win32&& shift & goto ArgLoop)
+if /i [%1] == [android] (set _ANDROID_ABI=%2&& set _BUILD_ARCH=%2&& shift && shift & goto ArgLoop)
 if /i [%1] == [--android-ndk] (set _NDK_DIR=%2&& shift && shift & goto ArgLoop)
-if /i [%1] == [--android-abi] (set _ANDROID_ABI=%2&& set _BUILD_ARCH=%2&& shift && shift & goto ArgLoop)
-if /i [%1] == [--artifact-name] (set _ARTIFACT_NAME=%2&& shift && shift & goto ArgLoop)
 if /i [%1] == [--android-platform] (set _ANDROID_PLATFORM=%2&& shift && shift & goto ArgLoop)
 if /i [%1] == [--python-exe] (set _PYTHON_EXECUTABLE=%2&& shift && shift & goto ArgLoop)
 shift
@@ -42,12 +41,6 @@ if defined _PYTHON_EXECUTABLE (
 
 )
 
-if defined _NDK_DIR (
-  set _ARTIFACT_SRC=%_BUILD_DIR%\libveldrid-spirv.so
-) else (
-  set _ARTIFACT_SRC=%_BUILD_DIR%\libveldrid-spirv.dll
-)
-
 set _CMAKE_ARGS=%_CMAKE_ARGS% ..\..\..
 
 If NOT exist "%BUILD_DIR%" (
@@ -58,11 +51,6 @@ cmake %_CMAKE_ARGS%
 cmake --build . --config %_CMAKE_BUILD_TYPE% --target veldrid-spirv
 copy .\%_CMAKE_BUILD_TYPE%\* .\
 popd
-
-if defined _ARTIFACT_NAME (
-  echo "Copying %_ARTIFACT_SRC% -> %_ARTIFACT_NAME%"
-  copy %_ARTIFACT_SRC% %_ARTIFACT_NAME%
-)
 
 :Success
 exit /b 0

--- a/build-native.cmd
+++ b/build-native.cmd
@@ -11,8 +11,8 @@ set _ANDROID_PLATFORM=android-16
 
 :ArgLoop
 if [%1] == [] goto LocateVS
-if /i [%1] == [Release] (set _CMAKE_BUILD_TYPE=Release&& shift & goto ArgLoop)
-if /i [%1] == [Debug] (set _CMAKE_BUILD_TYPE=Debug&& shift & goto ArgLoop)
+if /i [%1] == [release] (set _CMAKE_BUILD_TYPE=Release&& shift & goto ArgLoop)
+if /i [%1] == [debug] (set _CMAKE_BUILD_TYPE=Debug&& shift & goto ArgLoop)
 if /i [%1] == [win-x64] (set _BUILD_ARCH=x64&& set _CMAKE_GENERATOR_PLATFORM=x64&& shift & goto ArgLoop)
 if /i [%1] == [win-x86] (set _BUILD_ARCH=x86&& set _CMAKE_GENERATOR_PLATFORM=Win32&& shift & goto ArgLoop)
 if /i [%1] == [--android-ndk] (set _NDK_DIR=%2&& shift && shift & goto ArgLoop)
@@ -35,7 +35,7 @@ if defined _NDK_DIR (
   set _OS_DIR=win
 )
 
-set _BUILD_DIR=.\build\%_OS_DIR%-%_BUILD_ARCH%
+set _BUILD_DIR=.\build\%_CMAKE_BUILD_TYPE%\%_OS_DIR%-%_BUILD_ARCH%
 
 if defined _PYTHON_EXECUTABLE (
   set _CMAKE_ARGS=%_CMAKE_ARGS% -DPYTHON_EXECUTABLE=%_PYTHON_EXECUTABLE%
@@ -45,10 +45,10 @@ if defined _PYTHON_EXECUTABLE (
 if defined _NDK_DIR (
   set _ARTIFACT_SRC=%_BUILD_DIR%\libveldrid-spirv.so
 ) else (
-  set _ARTIFACT_SRC=%_BUILD_DIR%\%_CMAKE_BUILD_TYPE%\libveldrid-spirv.dll
+  set _ARTIFACT_SRC=%_BUILD_DIR%\libveldrid-spirv.dll
 )
 
-set _CMAKE_ARGS=%_CMAKE_ARGS% ..\..
+set _CMAKE_ARGS=%_CMAKE_ARGS% ..\..\..
 
 If NOT exist "%BUILD_DIR%" (
   mkdir %_BUILD_DIR%
@@ -56,6 +56,7 @@ If NOT exist "%BUILD_DIR%" (
 pushd %_BUILD_DIR%
 cmake %_CMAKE_ARGS%
 cmake --build . --config %_CMAKE_BUILD_TYPE% --target veldrid-spirv
+copy .\%_CMAKE_BUILD_TYPE%\* .\
 popd
 
 if defined _ARTIFACT_NAME (

--- a/build-native.cmd
+++ b/build-native.cmd
@@ -49,7 +49,11 @@ If NOT exist "%BUILD_DIR%" (
 pushd %_BUILD_DIR%
 cmake %_CMAKE_ARGS%
 cmake --build . --config %_CMAKE_BUILD_TYPE% --target veldrid-spirv
+
+if "%_OS_DIR%" == "win" (
 copy .\%_CMAKE_BUILD_TYPE%\* .\
+)
+
 popd
 
 :Success

--- a/build-native.sh
+++ b/build-native.sh
@@ -10,6 +10,7 @@ _CMakeBuildTarget=veldrid-spirv
 _CMakeOsxArchitectures=
 _CMakeGenerator=
 _CMakeExtraBuildArgs=
+_OSDir=
 
 while :; do
     if [ $# -le 0 ]; then
@@ -24,18 +25,22 @@ while :; do
         release|-release)
             _CMakeBuildType=Release
             ;;
+        osx)
+            _CMakeOsxArchitectures=$2
+            _OSDir=osx
+            shift
+            ;;
+        linux-x64)
+            _OSDir=linux-x64
+            ;;
         ios)
             _CMakeToolchain=-DCMAKE_TOOLCHAIN_FILE=$scriptPath/ios/ios.toolchain.cmake
             _CMakePlatform=-DPLATFORM=OS64COMBINED
             _CMakeEnableBitcode=-DENABLE_BITCODE=0
-            _OutputPathPrefix=ios-
             _CMakeBuildTarget=veldrid-spirv-combined_genfile
             _CMakeGenerator="-G Xcode -T buildsystem=1"
             _CMakeExtraBuildArgs="--config Release"
-            ;;
-        -osx-architectures)
-            _CMakeOsxArchitectures=$2
-            shift
+            _OSDir=ios
             ;;
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
@@ -44,7 +49,7 @@ while :; do
     shift
 done
 
-_OutputPath=$scriptPath/build/$_OutputPathPrefix$_CMakeBuildType
+_OutputPath=$scriptPath/build/$_CMakeBuildType/$_OSDir
 _PythonExePath=$(which python3)
 if [[ $_PythonExePath == "" ]]; then
     echo Build failed: could not locate python executable.
@@ -53,6 +58,10 @@ fi
 
 mkdir -p $_OutputPath
 pushd $_OutputPath
-cmake ../.. -DCMAKE_BUILD_TYPE=$_CMakeBuildType $_CMakeGenerator $_CMakeToolchain $_CMakePlatform $_CMakeEnableBitcode -DPYTHON_EXECUTABLE=$_PythonExePath -DCMAKE_OSX_ARCHITECTURES="$_CMakeOsxArchitectures"
+cmake ../../.. -DCMAKE_BUILD_TYPE=$_CMakeBuildType $_CMakeGenerator $_CMakeToolchain $_CMakePlatform $_CMakeEnableBitcode -DPYTHON_EXECUTABLE=$_PythonExePath -DCMAKE_OSX_ARCHITECTURES="$_CMakeOsxArchitectures"
 cmake --build . --target $_CMakeBuildTarget $_CMakeExtraBuildArgs
+
+if [[ $_OSDir == "ios" ]]; then
+    cp ./$_CMakeBuildType-*/* ./
+fi
 popd

--- a/src/Veldrid.SPIRV.Tests/Veldrid.SPIRV.Tests.csproj
+++ b/src/Veldrid.SPIRV.Tests/Veldrid.SPIRV.Tests.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <Content Include="TestShaders/*" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(RepositoryRootDirectory)/build/win-x64/$(Configuration)/libveldrid-spirv.dll" Condition="Exists('$(RepositoryRootDirectory)/build/win-x64/$(Configuration)/libveldrid-spirv.dll')" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.dylib" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.dylib')" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.so" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.so')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/win-x64/libveldrid-spirv.dll" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/win-x64/libveldrid-spirv.dll')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/osx/libveldrid-spirv.dylib" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/osx/libveldrid-spirv.dylib')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/linux-x64/libveldrid-spirv.so" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/linux-x64/libveldrid-spirv.so')" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Veldrid.SPIRV.VariantCompiler/Veldrid.SPIRV.VariantCompiler.csproj
+++ b/src/Veldrid.SPIRV.VariantCompiler/Veldrid.SPIRV.VariantCompiler.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(RepositoryRootDirectory)/build/win-x64/$(Configuration)/libveldrid-spirv.dll" Condition="Exists('$(RepositoryRootDirectory)/build/win-x64/$(Configuration)/libveldrid-spirv.dll')" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.dylib" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.dylib')" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.so" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/libveldrid-spirv.so')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/win-x64/libveldrid-spirv.dll" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/win-x64/libveldrid-spirv.dll')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/osx/libveldrid-spirv.dylib" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/osx/libveldrid-spirv.dylib')" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(RepositoryRootDirectory)/build/$(Configuration)/linux-x64/libveldrid-spirv.so" Condition="Exists('$(RepositoryRootDirectory)/build/$(Configuration)/linux-x64/libveldrid-spirv.so')" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj
+++ b/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj
@@ -46,9 +46,9 @@
       <_NativeAssetName Include="$(Configuration)/android-armeabi-v7a/libveldrid-spirv.so" PackagePath="build/MonoAndroid10/native/armeabi-v7a" />
       <_NativeAssetName Include="$(Configuration)/android-x86_64/libveldrid-spirv.so" PackagePath="build/MonoAndroid10/native/x86_64" />
 
-      <_ExistingAssets Include="@(_NativeAssetName)" Condition="Exists('$(NativeAssetsPath)/%(Identity)')" />
+      <_ExistingAssets Include="@(_NativeAssetName)" Condition="Exists('$(NativeAssetsPath)%(Identity)')" />
 
-      <Content Include="@(_ExistingAssets->'$(NativeAssetsPath)/%(Identity)')" CopyToOutputDirectory="PreserveNewest" PackagePath="%(PackagePath)" Pack="true" />
+      <Content Include="@(_ExistingAssets->'$(NativeAssetsPath)%(Identity)')" CopyToOutputDirectory="PreserveNewest" PackagePath="%(PackagePath)" Pack="true" />
     </ItemGroup>
   </Target>
 

--- a/src/Veldrid.SPIRV/build/net40/Veldrid.SPIRV.targets
+++ b/src/Veldrid.SPIRV/build/net40/Veldrid.SPIRV.targets
@@ -5,13 +5,13 @@
     <_Veldrid_SPIRV_IsMacOS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</_Veldrid_SPIRV_IsMacOS>
     <_Veldrid_SPIRV_IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</_Veldrid_SPIRV_IsLinux>
 
-    <_Veldrid_SPIRV_NativeRuntime Condition=" '$(_Veldrid_SPIRV_NativeRuntime)' == '' And '$(_Veldrid_SPIRV_IsMacOS)' == 'true' And ('$(Prefer32Bit)' == 'false' Or '$(PlatformTarget)' == 'x64')">osx-x64</_Veldrid_SPIRV_NativeRuntime>
+    <_Veldrid_SPIRV_NativeRuntime Condition=" '$(_Veldrid_SPIRV_NativeRuntime)' == '' And '$(_Veldrid_SPIRV_IsMacOS)' == 'true'">osx</_Veldrid_SPIRV_NativeRuntime>
     <_Veldrid_SPIRV_NativeRuntime Condition=" '$(_Veldrid_SPIRV_NativeRuntime)' == '' And '$(_Veldrid_SPIRV_IsLinux)' == 'true' And ('$(Prefer32Bit)' == 'false' Or '$(PlatformTarget)' == 'x64')">linux-x64</_Veldrid_SPIRV_NativeRuntime>
     <_Veldrid_SPIRV_NativeRuntime Condition=" '$(_Veldrid_SPIRV_NativeRuntime)' == '' And '$(_Veldrid_SPIRV_IsWindows)' == 'true' And ('$(Prefer32Bit)' == 'true' Or '$(PlatformTarget)' == 'x86')">win-x86</_Veldrid_SPIRV_NativeRuntime>
     <_Veldrid_SPIRV_NativeRuntime Condition=" '$(_Veldrid_SPIRV_NativeRuntime)' == '' And '$(_Veldrid_SPIRV_IsWindows)' == 'true' And ('$(Prefer32Bit)' == 'false' Or '$(PlatformTarget)' == 'x64')">win-x64</_Veldrid_SPIRV_NativeRuntime>
 
     <_Veldrid_SPIRV_NativeLibName Condition="'$(_Veldrid_SPIRV_NativeRuntime)' == 'win-x86' Or '$(_Veldrid_SPIRV_NativeRuntime)' == 'win-x64'">libveldrid-spirv.dll</_Veldrid_SPIRV_NativeLibName>
-    <_Veldrid_SPIRV_NativeLibName Condition="'$(_Veldrid_SPIRV_NativeRuntime)' == 'osx-x64'">libveldrid-spirv.dylib</_Veldrid_SPIRV_NativeLibName>
+    <_Veldrid_SPIRV_NativeLibName Condition="'$(_Veldrid_SPIRV_NativeRuntime)' == 'osx'">libveldrid-spirv.dylib</_Veldrid_SPIRV_NativeLibName>
     <_Veldrid_SPIRV_NativeLibName Condition="'$(_Veldrid_SPIRV_NativeRuntime)' == 'linux-x64'">libveldrid-spirv.so</_Veldrid_SPIRV_NativeLibName>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This comes with a list of changes that help in improving the current status of CI, bringing it to a working state.

Mainly revolving around standardising the native build output directory across all platforms to `/build/{configuration}/{platform}/{library_file}`, as it was completely different across different platforms:
 - On windows, it was outputting to `/build/win-{x64/x86}/Release/libveldrid-spirv.dll`
 - On macOS and linux, it was outputting to `/build/Release/libveldrid-spirv.{dylib/so}`
 - On iOS, it was outputting to `/build/ios-Release/Release-iphoneos`

This caused libraries to not be found when running tests. And in addition, this also caused the NuGet packaging inclusions in `Veldrid.SPIRV.csproj` to not be fully correct (looks to have been aided with mapping in the CI itself, from output folder to "aritfact path" for uploading).

This also comes with https://github.com/mellinoe/veldrid-spirv/commit/8feba9815697a10e66e03645bf26ed2f9a0d5628 which fixes a major issue in NuGet packaging not including the `runtimes` folder, due to the `--no-build` flag. Merging it with the building step before it should be fine.