### PR TITLE
Fix 'invalid string position' error when using Structured Buffers in GL

### DIFF
--- a/src/libveldrid-spirv/libveldrid-spirv.cpp
+++ b/src/libveldrid-spirv/libveldrid-spirv.cpp
@@ -456,12 +456,12 @@ CompilationResult *CompileVertexFragment(const CrossCompileInfo &info)
     if (info.Target == GLSL && usesStorageResource)
     {
         std::string key = "#version 330";
-        fsText.replace(vsText.find(key), key.length(), "#version 430");
+        fsText.replace(fsText.find(key), key.length(), "#version 430");
     }
     else if (info.Target == ESSL && usesStorageResource)
     {
         std::string key = "#version 300";
-        fsText.replace(vsText.find(key), key.length(), "#version 310");
+        fsText.replace(fsText.find(key), key.length(), "#version 310");
     }
 
     CompilationResult *result = new CompilationResult();


### PR DESCRIPTION
When using libveldrid-spirv to cross compile Vulkan-style GLSL to GL GLSL an "invalid string position" exception was thrown if the fragment shader included any structured buffers. The issue was that the wrong string is passed to the version number replacement calls for fragment shaders.